### PR TITLE
Removed hour/minutes timestamp

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -61,7 +61,7 @@ exports['default'] = function () {
                     this.testrailConfig.password = process.env.TESTRAIL_PASSWORD;
                     this.testrailConfig.user = process.env.TESTRAIL_USER;
                     this.testrailConfig.testPlan = process.env.PLAN_NAME || 'TestPlan';
-                    this.taskRunDate = this.moment(new Date()).format('MMMM Do YYYY, h:mm:ss a');
+                    this.taskRunDate = this.moment(new Date()).format('MMMM Do YYYY');
                     if (!Object.values(this.testrailConfig).every(function (entry) { return !!entry; })) {
                         this.newline().write(this.chalk.red.bold('Error:  TESTRAIL_HOST, TESTRAIL_USER, TESTRAIL_PASSWORD and PROJECT_NAME must be set as environment variables for the reporter plugin to push the result to the Testrail'));
                         process.exit(1);


### PR DESCRIPTION
Removed hour/minutes timestamp

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
I need only Date in the name of the test run created. I removed hour/minutes timestamp.
- **What is the current behavior?** (You can also link to an open issue here)
this.taskRunDate = this.moment(new Date()).format('MMMM Do YYYY, h:mm:ss a');
- **What is the new behavior (if this is a feature change)?**
this.taskRunDate = this.moment(new Date()).format('MMMM Do YYYY');
- **Other information**:
